### PR TITLE
Fixed compile error due to union struct

### DIFF
--- a/NMEA2000_esp32.cpp
+++ b/NMEA2000_esp32.cpp
@@ -113,12 +113,14 @@ bool tNMEA2000_esp32::CANSendStandardFrame(unsigned long id, unsigned char len, 
     
 bool tNMEA2000_esp32::CANSendFrame(unsigned long id, unsigned char len, const unsigned char *buf, bool wait_sent) {
     twai_message_t message = {
-        .extd = 1,
-        .rtr = 0,
-        .ss = 0,
-        .self = 0,
-        .dlc_non_comp = 0,
-        .reserved = 0,
+//        .extd = 1,
+//        .rtr = 0,
+//        .ss = 0,
+//        .self = 0,
+//        .dlc_non_comp = 0,
+//        .reserved = 0,
+// some compilers cant cope with union->struct above, setting the 32 bit flags directly below.
+        .flags = 0x01,
         .identifier = id,
         .data_length_code = static_cast<uint8_t>(len > 8 ? 8 : len),
         .data = {0}


### PR DESCRIPTION
This fixes 

      .pio/libdeps/esp32-c3/NMEA2000_twai/NMEA2000_esp32.cpp:127:5: error: designator order for field 'twai_message_t::<unnamed union>::<unnamed struct>::rtr' does not match declaration order in 'twai_message_t'

for me, when compilint in a project with a default setup for PlatformIO using 

        [env]
         platform = espressif32
         board = esp32-c3-devkitm-1
         framework = arduino
     
     
The struct in twai_types.h I have under .platformio for the esp32-c3 is

          /**
           * @brief   Structure to store a TWAI message
           *
           * @note    The flags member is deprecated
           */
          typedef struct {
              union {
                  struct {
                      //The order of these bits must match deprecated message flags for compatibility reasons
                      uint32_t extd: 1;           /**< Extended Frame Format (29bit ID) */
                      uint32_t rtr: 1;            /**< Message is a Remote Frame */
                      uint32_t ss: 1;             /**< Transmit as a Single Shot Transmission. Unused for received. */
                      uint32_t self: 1;           /**< Transmit as a Self Reception Request. Unused for received. */
                      uint32_t dlc_non_comp: 1;   /**< Message's Data length code is larger than 8. This will break compliance with ISO 11898-1 */
                      uint32_t reserved: 27;      /**< Reserved bits */
                  };
                  //Todo: Deprecate flags
                  uint32_t flags;                 /**< Deprecated: Alternate way to set bits using message flags */
              };
              uint32_t identifier;                /**< 11 or 29 bit identifier */
              uint8_t data_length_code;           /**< Data length code */
              uint8_t data[TWAI_FRAME_MAX_DLC];    /**< Data bytes (not relevant in RTR frame) */
          } twai_message_t;


My only concern is .flags is deprecated.