### PR TITLE
perf: make error monitor task stack configurable, default 2048

### DIFF
--- a/NMEA2000_esp32.cpp
+++ b/NMEA2000_esp32.cpp
@@ -82,7 +82,7 @@ bool tNMEA2000_esp32::CANOpen()
     if (is_open_) return true;
     CAN_init();
     //is_open_ = true;
-    xTaskCreate(errorMonitorTask, "TWAI_errMonitor", 4096, this, 5, &error_monitor_task_handle_);
+    xTaskCreate(errorMonitorTask, "TWAI_errMonitor", TWAI_ERROR_MONITOR_STACK_SIZE, this, 5, &error_monitor_task_handle_);
     return true;
 }
 

--- a/NMEA2000_esp32.h
+++ b/NMEA2000_esp32.h
@@ -1,4 +1,9 @@
 #pragma once
+
+#ifndef TWAI_ERROR_MONITOR_STACK_SIZE
+#define TWAI_ERROR_MONITOR_STACK_SIZE 2048
+#endif
+
 #include "freertos/FreeRTOS.h"
 #include "driver/gpio.h"
 #include "driver/twai.h"


### PR DESCRIPTION
## Summary

- Reduce `TWAI_errMonitor` task stack from 4096 to 2048 bytes (default), saving 2 KB of heap
- Make stack size build-time configurable via `TWAI_ERROR_MONITOR_STACK_SIZE`

## Motivation

On memory-constrained devices like ESP32-C3, every kilobyte counts. The error monitor task doesn't need 4096 bytes of stack, but 1024 proved insufficient — the `handleBusError()` path with `ESP_LOG` formatting caused stack overflow crashes in production.

2048 bytes provides safe headroom while still saving 2 KB. Projects with tighter constraints can override via `-D TWAI_ERROR_MONITOR_STACK_SIZE=<value>` in `platformio.ini`.

## Test plan

- [x] Verified on ESP32-C3 (HALSER board) with NMEA 2000 bus active
- [x] Confirmed 1024 causes stack protection fault on error path (crash in `TWAI_errMonitor`)
- [x] Confirmed 2048 runs stable with no crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)