### PR TITLE
Use non-blocking CAN transmit to prevent event loop stalls

### DIFF
--- a/NMEA2000_esp32.cpp
+++ b/NMEA2000_esp32.cpp
@@ -141,12 +141,12 @@ bool tNMEA2000_esp32::CANSendFrame(unsigned long id, unsigned char len, const un
         .data = {0}
     };
     memcpy(message.data, buf, message.data_length_code);
-    //todo this could use some love when doing microsleep
-    esp_err_t result = twai_transmit_v2(twai_handle_, &message, wait_sent ? pdMS_TO_TICKS(100) : 0);
-    if (result != ESP_OK)
-    {
-        //ESP_LOGE(TAG, "Failed to transmit message: %s", esp_err_to_name(result));
-    }
+    // Never block on transmit. The TWAI driver has its own TX queue for
+    // buffering, and the NMEA2000 library maintains a send buffer above
+    // this layer. Blocking here (e.g. 100ms per frame) causes catastrophic
+    // event loop stalls when the CAN bus is faulty or unterminated and the
+    // controller enters bus-off recovery.
+    esp_err_t result = twai_transmit_v2(twai_handle_, &message, 0);
     return (result == ESP_OK);
 }
 


### PR DESCRIPTION
## Summary

- Make `CANSendFrame` non-blocking by passing timeout 0 to `twai_transmit_v2()` instead of 100ms when `wait_sent` is true

## Problem

When the CAN bus is faulty or unterminated, the TWAI controller enters bus-off recovery and frames cannot drain from the TX queue. The previous 100ms blocking timeout per frame caused cumulative stalls of 400ms+ in the calling thread — the NMEA2000 library's `SendFrames()` loops through buffered frames, and each `CANSendFrame()` call blocks for the full timeout.

In single-threaded event loop architectures (e.g. SensESP/ReactESP), this stall triggers a cascading event batching collapse that drops the event loop rate from tens of thousands of ticks/s to ~1.5/s permanently.

## Approach

The TWAI driver maintains its own 40-frame TX queue, and the NMEA2000 library maintains an additional send buffer above this layer (`CANSendFrameBuf`). When the TX queue is full, `twai_transmit_v2()` with timeout 0 fails immediately, `CANSendFrame` returns false, and the NMEA2000 library buffers the frame for retry on the next `ParseMessages()` cycle. There is no need to block at the driver level.

## Test plan

- Tested on HALMET (ESP32) with NMEA 2000 bus disconnected (no termination)
- Before fix: event loop collapsed to 1.5 ticks/s due to 400ms blocking per N2K send
- After fix: event loop stable at 36,000+ ticks/s with max tick duration of 19ms
- Also verified normal operation with a working NMEA 2000 bus: 41,000+ ticks/s

🤖 Generated with [Claude Code](https://claude.com/claude-code)