### PR TITLE
Survive an absent/faulty CAN bus: fix bus-off teardown race + log flood

### DIFF
--- a/NMEA2000_esp32.cpp
+++ b/NMEA2000_esp32.cpp
@@ -10,7 +10,11 @@ tNMEA2000_esp32::tNMEA2000_esp32(
     CAN_speed_t can_speed) : tNMEA2000(),
                              is_open_(false),
                              error_monitor_task_handle_(nullptr),
-                             should_stop_error_monitor_(false)
+                             should_stop_error_monitor_(false),
+                             error_monitor_running_(false),
+                             can_mutex_(xSemaphoreCreateMutex()),
+                             not_open_reported_(false),
+                             busoff_reported_(false)
 {
     switch (can_speed)
     {
@@ -55,11 +59,18 @@ tNMEA2000_esp32::tNMEA2000_esp32(
 tNMEA2000_esp32::~tNMEA2000_esp32()
 {
     should_stop_error_monitor_ = true;
-    if (error_monitor_task_handle_ != nullptr)
+    // Wait for the monitor task to exit on its own (it deletes itself when it
+    // sees the stop flag) rather than force-deleting it, so it is never killed
+    // while holding can_mutex_. Capped so a wedged task can't hang teardown.
+    for (int i = 0; error_monitor_running_ && i < 500; i++)
     {
-        vTaskDelete(error_monitor_task_handle_);
+        vTaskDelay(pdMS_TO_TICKS(10));
     }
     CAN_deinit();
+    if (can_mutex_ != nullptr)
+    {
+        vSemaphoreDelete(can_mutex_);
+    }
 }
 
 void tNMEA2000_esp32::SetCANBufferSize(uint16_t RxBufferSize, uint16_t TxBufferSize)
@@ -82,20 +93,30 @@ bool tNMEA2000_esp32::CANOpen()
     if (is_open_) return true;
     CAN_init();
     //is_open_ = true;
-    xTaskCreate(errorMonitorTask, "TWAI_errMonitor", TWAI_ERROR_MONITOR_STACK_SIZE, this, 5, &error_monitor_task_handle_);
+    if (xTaskCreate(errorMonitorTask, "TWAI_errMonitor", TWAI_ERROR_MONITOR_STACK_SIZE, this, 5, &error_monitor_task_handle_) == pdPASS)
+    {
+        error_monitor_running_ = true;
+    }
     return true;
 }
 
 void tNMEA2000_esp32::CAN_init()
 {
-    ESP_LOGI(TAG, "Initializing TWAI driver");
+    xSemaphoreTake(can_mutex_, portMAX_DELAY);
+    if (!busoff_reported_)
+    {
+        ESP_LOGI(TAG, "Initializing TWAI driver");
+    }
     esp_err_t result = twai_driver_install_v2(&g_config_, &t_config_, &f_config_, &twai_handle_);
     if (result == ESP_OK)
     {
         result = twai_start_v2(twai_handle_);
         if (result == ESP_OK)
         {
-            ESP_LOGI(TAG, "TWAI driver started successfully");
+            if (!busoff_reported_)
+            {
+                ESP_LOGI(TAG, "TWAI driver started successfully");
+            }
             is_open_ = true;
         }
         else
@@ -107,23 +128,36 @@ void tNMEA2000_esp32::CAN_init()
     {
         ESP_LOGE(TAG, "Failed to install TWAI driver: %s", esp_err_to_name(result));
     }
+    xSemaphoreGive(can_mutex_);
 }
 
 void tNMEA2000_esp32::CAN_deinit()
 {
+    xSemaphoreTake(can_mutex_, portMAX_DELAY);
     if (is_open_)
     {
-        ESP_LOGI(TAG, "Stopping TWAI driver");
+        // Mark closed before tearing down so a concurrent send/receive that
+        // is waiting on the mutex sees the closed state once it acquires it.
+        is_open_ = false;
+        if (!busoff_reported_)
+        {
+            ESP_LOGI(TAG, "Stopping TWAI driver");
+        }
         twai_stop_v2(twai_handle_);
         twai_driver_uninstall_v2(twai_handle_);
-        is_open_ = false;
     }
+    xSemaphoreGive(can_mutex_);
 }
 
 bool tNMEA2000_esp32::CANSendFrame(unsigned long id, unsigned char len, const unsigned char* buf, bool wait_sent)
 {
+    xSemaphoreTake(can_mutex_, portMAX_DELAY);
     if (!is_open_) {
-        ESP_LOGI(TAG, "CANSendFrame - not open...");
+        xSemaphoreGive(can_mutex_);
+        if (!not_open_reported_) {
+            ESP_LOGE(TAG, "CAN port not open; suppressing further messages until recovery");
+            not_open_reported_ = true;
+        }
         return false;
     }
 
@@ -147,24 +181,41 @@ bool tNMEA2000_esp32::CANSendFrame(unsigned long id, unsigned char len, const un
     // event loop stalls when the CAN bus is faulty or unterminated and the
     // controller enters bus-off recovery.
     esp_err_t result = twai_transmit_v2(twai_handle_, &message, 0);
+    xSemaphoreGive(can_mutex_);
     return (result == ESP_OK);
 }
 
 bool tNMEA2000_esp32::CANGetFrame(unsigned long& id, unsigned char& len, unsigned char* buf)
 {
+    xSemaphoreTake(can_mutex_, portMAX_DELAY);
     if (!is_open_) {
-        ESP_LOGI(TAG, "CANGetFrame - not open...");
+        xSemaphoreGive(can_mutex_);
+        if (!not_open_reported_) {
+            ESP_LOGE(TAG, "CAN port not open; suppressing further messages until recovery");
+            not_open_reported_ = true;
+        }
         return false;
     }
     twai_message_t message;
-    if (twai_receive_v2(twai_handle_, &message, 0) == ESP_OK)
+    bool received = (twai_receive_v2(twai_handle_, &message, 0) == ESP_OK);
+    xSemaphoreGive(can_mutex_);
+
+    if (!received)
     {
-        id = message.identifier;
-        len = message.data_length_code;
-        memcpy(buf, message.data, len);
-        return true;
+        return false;
     }
-    return false;
+
+    // A received frame means the bus is alive again: re-arm the report-once
+    // flags so a future outage is reported.
+    if (busoff_reported_ || not_open_reported_) {
+        ESP_LOGI(TAG, "CAN bus recovered");
+        busoff_reported_ = false;
+        not_open_reported_ = false;
+    }
+    id = message.identifier;
+    len = message.data_length_code;
+    memcpy(buf, message.data, len);
+    return true;
 }
 
 void tNMEA2000_esp32::errorMonitorTask(void* pvParameters)
@@ -172,8 +223,7 @@ void tNMEA2000_esp32::errorMonitorTask(void* pvParameters)
     auto* instance = static_cast<tNMEA2000_esp32*>(pvParameters);
     twai_status_info_t status_info;
 
-    // Timestamps for last logged messages (in milliseconds)
-    uint32_t last_busoff_log = 0;
+    // Timestamp for the last high-error-counter warning (in milliseconds)
     uint32_t last_highcounter_log = 0;
     const uint32_t LOG_INTERVAL = 60000; // 1 minute in milliseconds
 
@@ -185,11 +235,7 @@ void tNMEA2000_esp32::errorMonitorTask(void* pvParameters)
         {
             if (status_info.state == TWAI_STATE_BUS_OFF)
             {
-                if (current_time - last_busoff_log >= LOG_INTERVAL)
-                {
-                    ESP_LOGE(TAG, "Bus-off condition detected");
-                    last_busoff_log = current_time;
-                }
+                // handleBusError reports the bus-off once and reinitializes.
                 instance->handleBusError();
             }
             else if (status_info.tx_error_counter > 127 || status_info.rx_error_counter > 127)
@@ -205,12 +251,18 @@ void tNMEA2000_esp32::errorMonitorTask(void* pvParameters)
         vTaskDelay(pdMS_TO_TICKS(1000)); // Check every second
     }
 
+    instance->error_monitor_running_ = false;
     vTaskDelete(nullptr);
 }
 
 void tNMEA2000_esp32::handleBusError()
 {
-    ESP_LOGI(TAG, "Handling bus error: Reinitializing TWAI driver");
+    // Report once per outage; the flag (cleared on recovery in CANGetFrame)
+    // also silences the per-cycle reinit logs in CAN_deinit/CAN_init.
+    if (!busoff_reported_) {
+        ESP_LOGE(TAG, "Bus-off; reinitializing TWAI every 2s, suppressing further messages until recovery");
+        busoff_reported_ = true;
+    }
     CAN_deinit();
     vTaskDelay(pdMS_TO_TICKS(1000)); // Wait for 1 second before reinitializing
     CAN_init();

--- a/NMEA2000_esp32.h
+++ b/NMEA2000_esp32.h
@@ -5,6 +5,7 @@
 #endif
 
 #include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
 #include "driver/gpio.h"
 #include "driver/twai.h"
 #include "NMEA2000.h"
@@ -53,4 +54,16 @@ private:
     bool is_open_;
     TaskHandle_t error_monitor_task_handle_;
     volatile bool should_stop_error_monitor_;
+    // True while the error-monitor task is alive; lets the destructor wait for
+    // the task to exit on its own instead of force-deleting it (which could
+    // kill it while it holds can_mutex_ and deadlock CAN_deinit).
+    volatile bool error_monitor_running_;
+
+    // Serializes access to the TWAI handle so the error-monitor task cannot
+    // uninstall the driver while another task is transmitting or receiving.
+    SemaphoreHandle_t can_mutex_;
+    // "Report once" flags, re-armed only on genuine recovery (a received
+    // frame), to keep a missing/faulty bus from flooding the log.
+    bool not_open_reported_;
+    bool busoff_reported_;
 };


### PR DESCRIPTION
## Summary

Make the driver survive an absent, unterminated, or faulty CAN bus without rebooting or flooding the log. Two related commits:

1. **Non-blocking transmit** — `CANSendFrame` no longer blocks waiting for the frame to be sent.
2. **Bus-off teardown race + report-once logging** — fix a use-after-free that panics the chip, and stop the log flood.

## Why

With no other node on the bus (or an unterminated/faulty bus), frames are never ACKed, the controller's TX error counter saturates, and it enters **bus-off**. The error-monitor task then reinitializes the TWAI driver every ~2 s. On a real device (SH-ESP32, ESP-IDF Arduino) this produced:

- **A panic reboot after a while.** The monitor task calls `CAN_deinit()` → `twai_driver_uninstall_v2()` while another task is inside `twai_transmit_v2`/`twai_receive_v2` on the same handle. The `is_open_` check was not atomic with the TWAI call, and `is_open_` was cleared only *after* uninstall, so a transmit/receive could touch a handle being torn down → use-after-free → `Guru Meditation Error (... panic'ed)`, `rst:0xc (SW_CPU_RESET)`. It's probabilistic, so it shows up "after a while," and a higher call rate makes it more likely.
- **A log flood.** `CANSendFrame`/`CANGetFrame` logged "not open" on every call (hundreds/sec), and the reinit cycle logged on every iteration.

## What changed

- A FreeRTOS mutex guards the TWAI handle and `is_open_` across `CANSendFrame`, `CANGetFrame`, `CAN_init`, and `CAN_deinit`, so the monitor task cannot uninstall the driver mid-transmit/receive. `is_open_` is cleared before teardown.
- "Port not open" and "bus-off" are reported **once at ERROR**, re-armed only when a frame is actually *received* (a transmit returning OK only means "queued", so it isn't a reliable liveness signal). The per-cycle reinit logs are silenced. **Reinit cadence is unchanged** (still every ~2 s).
- The destructor shuts the error-monitor task down cooperatively (waits for it to exit via a flag) instead of force-deleting it, which could otherwise kill it while it holds the mutex and deadlock `CAN_deinit`.
- Non-blocking transmit: `twai_transmit_v2(..., 0)`. A blocking transmit stalls the caller's task; in an event-loop architecture (e.g. ReactESP, where `ParseMessages`/`SendMsg` run on one task) a faulty/bus-off bus made every send block the full timeout and stalled everything. The driver's TX queue plus the NMEA2000 library's own send buffer provide backpressure.

## Tradeoff to flag

The non-blocking change means `CANSendFrame` **ignores `wait_sent`** — a caller requesting a confirmed/blocking send no longer gets one. In practice the NMEA2000 library's higher-level send buffer handles retries, and the event-loop-stall avoidance is worth it, but it is a behavior change worth your review.

## Testing

SH-ESP32, ESP-IDF Arduino, **no N2K bus connected**, 90–150 s runs:
- **Zero panics** (previously ~1 per minute).
- CAN log output down from thousands of lines to ~3 (one startup init, one "bus-off", one "not open").
- Normal operation (other tasks, GNSS, Signal K) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
