### PR TITLE
fix: recover from bus-off in place instead of uninstalling the driver

### DIFF
--- a/NMEA2000_esp32.cpp
+++ b/NMEA2000_esp32.cpp
@@ -235,8 +235,15 @@ void tNMEA2000_esp32::errorMonitorTask(void* pvParameters)
         {
             if (status_info.state == TWAI_STATE_BUS_OFF)
             {
-                // handleBusError reports the bus-off once and reinitializes.
+                // handleBusError reports the bus-off once and initiates recovery.
                 instance->handleBusError();
+            }
+            else if (status_info.state == TWAI_STATE_STOPPED)
+            {
+                // Recovery has completed (driver returns to STOPPED); restart it
+                // to resume normal operation. On a dead bus recovery never
+                // completes, so the driver simply idles in RECOVERING instead.
+                instance->resumeFromStopped();
             }
             else if (status_info.tx_error_counter > 127 || status_info.rx_error_counter > 127)
             {
@@ -257,13 +264,31 @@ void tNMEA2000_esp32::errorMonitorTask(void* pvParameters)
 
 void tNMEA2000_esp32::handleBusError()
 {
-    // Report once per outage; the flag (cleared on recovery in CANGetFrame)
-    // also silences the per-cycle reinit logs in CAN_deinit/CAN_init.
+    // Report once per outage; the flag is re-armed on genuine recovery in
+    // CANGetFrame (a received frame).
     if (!busoff_reported_) {
-        ESP_LOGE(TAG, "Bus-off; reinitializing TWAI every 2s, suppressing further messages until recovery");
+        ESP_LOGE(TAG, "Bus-off; initiating TWAI recovery, suppressing further messages until recovery");
         busoff_reported_ = true;
     }
-    CAN_deinit();
-    vTaskDelay(pdMS_TO_TICKS(1000)); // Wait for 1 second before reinitializing
-    CAN_init();
+    // Recover in place. twai_initiate_recovery_v2 transitions BUS_OFF ->
+    // RECOVERING without uninstalling the driver; the monitor restarts it once
+    // it returns to STOPPED. A full uninstall/reinstall here trips an ESP-IDF
+    // assertion in vSemaphoreDeleteWithCaps (twai_driver_uninstall_v2) and
+    // panics, so the driver must stay installed.
+    xSemaphoreTake(can_mutex_, portMAX_DELAY);
+    if (is_open_)
+    {
+        twai_initiate_recovery_v2(twai_handle_);
+    }
+    xSemaphoreGive(can_mutex_);
+}
+
+void tNMEA2000_esp32::resumeFromStopped()
+{
+    xSemaphoreTake(can_mutex_, portMAX_DELAY);
+    if (is_open_)
+    {
+        twai_start_v2(twai_handle_);
+    }
+    xSemaphoreGive(can_mutex_);
 }

--- a/NMEA2000_esp32.h
+++ b/NMEA2000_esp32.h
@@ -47,6 +47,8 @@ private:
 
     void handleBusError();
 
+    void resumeFromStopped();
+
     twai_timing_config_t t_config_;
     twai_filter_config_t f_config_;
     twai_general_config_t g_config_;


### PR DESCRIPTION
## Problem

`errorMonitorTask` responds to `TWAI_STATE_BUS_OFF` by fully tearing down and reinstalling the driver: `handleBusError()` calls `CAN_deinit()` (`twai_stop_v2` + `twai_driver_uninstall_v2`) then `CAN_init()`, every ~2 s while bus-off persists.

On recent ESP-IDF, `twai_driver_uninstall_v2()` → `twai_free_driver_obj()` → `vSemaphoreDeleteWithCaps()` trips an assertion and `abort()`s. So any node that actually reaches bus-off — transmitting periodic PGNs into a bus with no other node to ACK, or with a transceiver that can't drive the bus (e.g. a bus-powered isolated transceiver with no bus power) — panics and reboot-loops:

```
__assert_func
vSemaphoreDeleteWithCaps      (idf_additions.c)
twai_free_driver_obj          (twai.c)
twai_driver_uninstall_v2      (twai.c)
tNMEA2000_esp32::CAN_deinit()
tNMEA2000_esp32::handleBusError()
tNMEA2000_esp32::errorMonitorTask()
```

## Fix

Recover in place instead of uninstalling. On bus-off, `handleBusError()` now calls `twai_initiate_recovery_v2()` — the IDF-supported recovery path, which transitions `BUS_OFF → RECOVERING` **without** uninstalling the driver. The monitor watches for the driver returning to `STOPPED` (recovery complete) and restarts it with `twai_start_v2()`.

On a live bus, recovery completes and the node resumes. On a dead/absent bus, recovery never completes, so the driver idles in `RECOVERING` — no transmits, no teardown, no panic — and resumes automatically when a real bus appears. The driver stays installed throughout, so the asserting uninstall path is never reached. Both new calls are guarded by the existing `can_mutex_`.

## Validation

Reproduced on an SH-ESP32 (ESP32-WROOM, pioarduino / IDF 5.x): a node transmitting NMEA 2000 PGNs into a disconnected bus reaches bus-off ~1 s after enabling outputs and, on the old uninstall/reinstall path, panics with the assertion above. With this change it recovers in place and runs indefinitely with no panic from the bus-off path, re-arming cleanly when a bus is reattached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
